### PR TITLE
Issue: Compilation failure after adding Lombok NonNull annotation to JDO Entity fields

### DIFF
--- a/module-simple/src/main/java/domainapp/modules/simple/dom/so/SimpleObject.java
+++ b/module-simple/src/main/java/domainapp/modules/simple/dom/so/SimpleObject.java
@@ -28,6 +28,8 @@ import static org.apache.isis.applib.annotation.SemanticsOf.NON_IDEMPOTENT_ARE_Y
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.val;
@@ -61,6 +63,7 @@ import domainapp.modules.simple.types.Notes;
 @DomainObject(logicalTypeName = "simple.SimpleObject", entityChangePublishing = Publishing.ENABLED)
 @DomainObjectLayout()
 @NoArgsConstructor(access = AccessLevel.PUBLIC)
+@RequiredArgsConstructor
 @XmlJavaTypeAdapter(PersistentEntityAdapter.class)
 @ToString(onlyExplicitlyIncluded = true)
 public class SimpleObject implements Comparable<SimpleObject> {
@@ -82,12 +85,12 @@ public class SimpleObject implements Comparable<SimpleObject> {
 
     @Title
     @Name
-    @Getter @Setter @ToString.Include
+    @Getter @Setter @ToString.Include @NonNull
     @PropertyLayout(fieldSetId = "name", sequence = "1")
     private String name;
 
     @Notes
-    @Getter @Setter
+    @Getter @Setter @NonNull
     @Property(commandPublishing = Publishing.ENABLED, executionPublishing = Publishing.ENABLED)
     @PropertyLayout(fieldSetId = "name", sequence = "2")
     private String notes;


### PR DESCRIPTION
Based on the Apache Isis 2 SimpleApp JDO project (<https://github.com/apache/isis-app-simpleapp/tree/jdo>) I tried to slightly modify the `SimpleObject` class to mark some fields (`name` and `notes`) as not nullable using the Lombok annotation `@NonNull`. This unexpectedly results in a compilation failure:
```
Error:  Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project simpleapp-jdo-module-simple: Compilation failure: Compilation failure: 
Error:  /home/runner/work/isis-app-simpleapp/isis-app-simpleapp/module-simple/target/generated-sources/annotations/domainapp/modules/simple/dom/so/QSimpleObject.java:[35,51] cannot find symbol
Error:    symbol:   class java
Error:    location: class domainapp.modules.simple.dom.so.QSimpleObject
Error:  /home/runner/work/isis-app-simpleapp/isis-app-simpleapp/module-simple/target/generated-sources/annotations/domainapp/modules/simple/dom/so/QSimpleObject.java:[36,51] cannot find symbol
Error:    symbol:   class java
Error:    location: class domainapp.modules.simple.dom.so.QSimpleObject
Error:  -> [Help 1]
```
Related GitHub Action: <https://github.com/a-st/isis-app-simpleapp/runs/5330590432>
Related SO Post: <https://stackoverflow.com/q/71262961/6438521>