### PR TITLE
Example for resources in Wicket.

### DIFF
--- a/module-simple/src/main/java/domainapp/modules/simple/service/SimpleEchoService.java
+++ b/module-simple/src/main/java/domainapp/modules/simple/service/SimpleEchoService.java
@@ -1,0 +1,18 @@
+package domainapp.modules.simple.service;
+
+import org.apache.isis.applib.services.user.UserService;
+import org.springframework.stereotype.Service;
+
+import javax.inject.Inject;
+
+@Service
+public class SimpleEchoService {
+    @Inject
+    private UserService userService;
+
+    public String greet(String greeting) {
+        String username = userService.currentUserName().orElse("unknown user");
+
+        return greeting + ", " + username + "!";
+    }
+}

--- a/webapp/src/main/java/domainapp/webapp/AppManifest.java
+++ b/webapp/src/main/java/domainapp/webapp/AppManifest.java
@@ -1,5 +1,6 @@
 package domainapp.webapp;
 
+import domainapp.webapp.resource.CustomResourceInitializer;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.PropertySource;
@@ -67,6 +68,7 @@ import domainapp.webapp.quartz.QuartzModule;
 
         ApplicationModule.class,
         CustomModule.class,
+        CustomResourceInitializer.class,
         QuartzModule.class,
 
         // discoverable fixtures

--- a/webapp/src/main/java/domainapp/webapp/resource/CustomResource.java
+++ b/webapp/src/main/java/domainapp/webapp/resource/CustomResource.java
@@ -1,0 +1,31 @@
+package domainapp.webapp.resource;
+
+import domainapp.modules.simple.service.SimpleEchoService;
+import org.apache.wicket.request.resource.AbstractResource;
+
+import javax.inject.Inject;
+import java.io.IOException;
+
+public class CustomResource extends AbstractResource {
+
+    @Inject private SimpleEchoService simpleEchoService;
+
+    @Override
+    protected ResourceResponse newResourceResponse(Attributes attributes) {
+        String greeting = attributes.getParameters().get("greeting").toString();
+
+        ResourceResponse resourceResponse = new ResourceResponse();
+
+        resourceResponse.setStatusCode(200);
+        resourceResponse.setContentType("text/plain");
+        resourceResponse.disableCaching();
+        resourceResponse.setWriteCallback(new WriteCallback() {
+            @Override
+            public void writeData(Attributes attributes) throws IOException {
+                attributes.getResponse().write(simpleEchoService.greet(greeting));
+            }
+        });
+
+        return resourceResponse;
+    }
+}

--- a/webapp/src/main/java/domainapp/webapp/resource/CustomResourceInitializer.java
+++ b/webapp/src/main/java/domainapp/webapp/resource/CustomResourceInitializer.java
@@ -1,0 +1,18 @@
+package domainapp.webapp.resource;
+
+import org.apache.isis.viewer.wicket.model.isis.WicketApplicationInitializer;
+import org.apache.wicket.protocol.http.WebApplication;
+import org.springframework.context.annotation.Configuration;
+
+import javax.inject.Inject;
+
+@Configuration
+public class CustomResourceInitializer implements WicketApplicationInitializer {
+
+    @Inject CustomResourceReference customResourceReference;
+
+    @Override
+    public void init(WebApplication webApplication) {
+        webApplication.mountResource("/custom-resource-greet/${greeting}", customResourceReference);
+    }
+}

--- a/webapp/src/main/java/domainapp/webapp/resource/CustomResourceReference.java
+++ b/webapp/src/main/java/domainapp/webapp/resource/CustomResourceReference.java
@@ -1,0 +1,20 @@
+package domainapp.webapp.resource;
+
+import org.apache.wicket.request.resource.IResource;
+import org.apache.wicket.request.resource.ResourceReference;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CustomResourceReference extends ResourceReference {
+
+    public CustomResourceReference() {
+        super(CustomResourceReference.class, "custom-resource");
+    }
+
+    @Override
+    @Bean
+    public IResource getResource() {
+        return new CustomResource();
+    }
+}


### PR DESCRIPTION
As requested in Slack, this shows how Wicket Resources can be used to handle requests that are not pages. 