### PR TITLE
Null pointer Exception when editing the properties of a custom object type again after canceling the first edit.

### DIFF
--- a/module-simple/src/main/java/domainapp/modules/simple/dom/so/BugDescription.md
+++ b/module-simple/src/main/java/domainapp/modules/simple/dom/so/BugDescription.md
@@ -1,0 +1,35 @@
+**Subject:**
+
+Null pointer Exception when editing the properties of a custom object type again after canceling the first edit.
+
+**Description:**
+
+When the domain object property is of a custom object type, this property can be null, and the user will attempt to edit this property for the first time (which is null at this time). However, at this point, the user will not click Confirm but choose to cancel. After that, if the user chooses to edit this property again instead of leaving the page, the project will report a NullPointerException.
+
+**Steps to Reproduce:**
+
+1. Create a SimpleObject.
+2. Open the SimpleObject you just created. At this point, Position is null. Try to modify Position (Position is an enumeration type I defined myself, used to reproduce the problem). I have set Position as a property of SimpleObject.
+3. Select the Position attribute for editing, but after editing is completed, do not choose to confirm. Instead, choose to cancel editing and do not leave the page.
+4. Select the Position attribute again for editing.
+
+**Expected behavior:**
+
+Open the edit dialog box again without any error.
+
+**Actual behavior:**
+
+Throw NullPointerException.
+
+**Possible root cause:**
+
+During the cancellation operation, the ManagedObject is set to null by restoring the content of the dialog box instead of retaining the original ManagedObjectEmpty. Subsequent editing attempts to call ManagedObject and unconditionally call getMemento().
+
+**Suggested solution:**
+
+1. Add a null value check before calling getMemento () (the getObject() method in the SingleChoiceModel class)
+
+2. Consider not directly setting null values into ManagedProperty after unediting. (The onCancel() method in the InlinePromptContext class)
+
+   
+

--- a/module-simple/src/main/java/domainapp/modules/simple/dom/so/Position.java
+++ b/module-simple/src/main/java/domainapp/modules/simple/dom/so/Position.java
@@ -1,0 +1,6 @@
+package domainapp.modules.simple.dom.so;
+
+public enum Position {
+    MANAGER,
+    PARTNER
+}

--- a/module-simple/src/main/java/domainapp/modules/simple/dom/so/SimpleObject.java
+++ b/module-simple/src/main/java/domainapp/modules/simple/dom/so/SimpleObject.java
@@ -232,4 +232,10 @@ public class SimpleObject implements Comparable<SimpleObject>, CalendarEventable
         return comparator.compare(this, other);
     }
 
+    @Property(optionality = Optionality.OPTIONAL, editing = Editing.ENABLED)
+    @PropertyLayout(fieldSetId = LayoutConstants.FieldSetId.DETAILS, sequence = "4")
+    @Column(nullable = true)
+    @Getter @Setter
+    private Position position;
+
 }


### PR DESCRIPTION
step1:
<img width="1335" height="899" alt="object1" src="https://github.com/user-attachments/assets/5cc07302-42bf-420d-829d-04bc026bdfb8" />

step2:
<img width="1335" height="899" alt="object2" src="https://github.com/user-attachments/assets/af7621eb-6ab4-47e7-9cb4-5b1f4d8d6a03" />

step3:
<img width="1335" height="899" alt="object3" src="https://github.com/user-attachments/assets/6b7fd031-c4f8-400d-8d52-8d953bb5f4f5" />

bug:
<img width="1335" height="899" alt="bug1" src="https://github.com/user-attachments/assets/e520f576-232b-4df5-8142-f32159117b7c" />
<img width="1335" height="899" alt="bug2" src="https://github.com/user-attachments/assets/0a73769a-0039-4388-a987-fb51bd8e3459" />

For details, please refer to the attachment.
[BugDescription.md](https://github.com/user-attachments/files/23253241/BugDescription.md)
